### PR TITLE
Delaying JS execution & adding HTML fallback

### DIFF
--- a/source/layouts/post.erb
+++ b/source/layouts/post.erb
@@ -10,7 +10,9 @@
 
     <div class="codefund">
       <!-- BEGIN COPY CODEFUND EMBED -->
-      <div id="codefund"></div>
+      <div id="codefund">
+        Sponsored: Was this post helpful? Consider <a href="https://www.buymeacoffee.com/MikeRogers0" target="_blank" rel="noopener noreferrer">buying me a coffee</a> to show your appreciation :)
+      </div>
       <!-- END COPY CODEFUND EMBED -->
     </div>
 

--- a/source/layouts/post.erb
+++ b/source/layouts/post.erb
@@ -11,10 +11,6 @@
     <div class="codefund">
       <!-- BEGIN COPY CODEFUND EMBED -->
       <div id="codefund"></div>
-      <script
-        src="https://app.codefund.io/properties/856/funder.js"
-        async
-        ></script>
       <!-- END COPY CODEFUND EMBED -->
     </div>
 
@@ -63,4 +59,9 @@
       }
     </script>
   </article>
+
+  <script
+    src="https://app.codefund.io/properties/856/funder.js"
+    async
+    ></script>
 <% end %>

--- a/source/stylesheets/_codefund.scss
+++ b/source/stylesheets/_codefund.scss
@@ -1,3 +1,10 @@
 .codefund {
   margin-bottom: map-get($spacers, 3);
+  padding: map-get($spacers, 0) map-get($spacers, 3);
+  text-align: center;
+  color: #6c757e;
+  line-height: 1.7;
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
 }


### PR DESCRIPTION
Experimenting with moving the JS to the bottom of the page & having a fallback text. The aim is to avoid the content moving when ads are loaded, while also showing something to people with AdBlock enabled.

# Screenshots

Without JS (Or with an ad blocker), it'll look like:

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/325384/84592626-0b101f00-ae3f-11ea-8854-4cd6f16262b8.png">

With JS:

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/325384/84592652-2ed36500-ae3f-11ea-9ef9-698a22dc9c47.png">


It does switch content for a moment, but that that should be ok.