### PR TITLE
Adding redirect from old portfolio page to /projects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -56,6 +56,11 @@
   status = 301
 
 [[redirects]]
+  from = "/portfolio.html"
+  to = "/projects"
+  status = 301
+
+[[redirects]]
   from = "/my-pull-requests"
   to = "https://github.com/search?q=is%3Amerged+is%3Apr+author%3AMikeRogers0+archived%3Afalse+state%3Aclosed&type=Issues&ref=advsearch&l=&l="
   status = 302


### PR DESCRIPTION
I renamed the page in the rebuild, so adding 301 to the new page.