### PR TITLE
Not relying on NODE_ENV when BRIDGETOWN_ENV is more correct

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,6 @@
   publish = "build"
 
 [build.environment]
-  NODE_ENV = "production"
   NODE_VERSION = "12"
   BRIDGETOWN_ENV = "production"
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -15,7 +15,7 @@ let environment = {
 }
 
 // Only add these in production as they slow down the dev build time a bunch.
-if (process.env.NODE_ENV === "production") {
+if (process.env.BRIDGETOWN_ENV === "production") {
   environment.plugins.push(
     // https://github.com/TrySound/postcss-inline-svg
     // Inline SVGs:
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === "production") {
     // require('postcss-inline-svg'),
     //require('postcss-svgo')
 
-    require('cssnano')({ preset: 'default' }),
+    //require('cssnano')({ preset: 'default' }),
     
   )
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -23,7 +23,7 @@ if (process.env.BRIDGETOWN_ENV === "production") {
     // require('postcss-inline-svg'),
     //require('postcss-svgo')
 
-    //require('cssnano')({ preset: 'default' }),
+    require('cssnano')({ preset: 'default' }),
     
   )
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   purge: {
-    enabled: (process.env.NODE_ENV === 'production'),
+    enabled: (process.env.BRIDGETOWN_ENV === 'production'),
     content: [
       './src/**/*.html',
       './src/**/*.md',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const ManifestPlugin = require("webpack-manifest-plugin");
 
 module.exports = {
   entry: "./frontend/javascript/index.js",
-  devtool: (process.env.NODE_ENV === 'production' ? false : "source-map"),
+  devtool: (process.env.BRIDGETOWN_ENV === 'production' ? false : "source-map"),
   // Set some or all of these to true if you want more verbose logging:
   stats: {
     modules: false,
@@ -14,14 +14,14 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, "build", "_bridgetown", "static", "js"),
-    filename: (process.env.NODE_ENV === 'production' ? "all.[contenthash].js" : "all.js" ),
+    filename: (process.env.BRIDGETOWN_ENV === 'production' ? "all.[contenthash].js" : "all.js" ),
   },
   resolve: {
     extensions: [".js", ".jsx"],
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: (process.env.NODE_ENV === 'production' ? "../css/all.[contenthash].css" : "../css/all.css" ),
+      filename: (process.env.BRIDGETOWN_ENV === 'production' ? "../css/all.[contenthash].css" : "../css/all.css" ),
     }),
     new ManifestPlugin({
       fileName: path.resolve(__dirname, ".bridgetown-webpack", "manifest.json"),


### PR DESCRIPTION
Calling NODE_ENV doesn't install all the packages as I thought it would, the correct way is to use BRIDGETOWN_ENV.