### PR TITLE
Removing duplication of my name from Homepage title

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mike Rogers - Ruby Developer
+title: Ruby Developer
 ---
 
 <div class="container text-center my-24">


### PR DESCRIPTION
It was being clipped in the tab names, so updating it to just say my name once.