### PR TITLE
Fixing PurgeCSS - it was quietly failing

### DIFF
--- a/plugins/purgecss_builder.rb
+++ b/plugins/purgecss_builder.rb
@@ -12,6 +12,7 @@ class PurgeCSS < SiteBuilder
           PURGE
           File.write(purgecss_file, config_js.strip)
         end
+
         manifest_file = site.in_root_dir('.bridgetown-webpack', 'manifest.json')
         if File.exist?(manifest_file)
           manifest = JSON.parse(File.read(manifest_file))
@@ -20,7 +21,7 @@ class PurgeCSS < SiteBuilder
 
           Bridgetown.logger.info 'PurgeCSS', "Purging #{css_file}"
           oldsize = File.stat(css_path).size / 1000
-          system "./node_modules/.bin/purgecss -c purgecss.config.js -css #{css_path}"
+          system "./node_modules/.bin/purgecss -c purgecss.config.js -css #{css_path} --output #{css_path}"
           newsize = File.stat(css_path).size / 1000
           if newsize < oldsize
             Bridgetown.logger.info 'PurgeCSS', "Done! File size reduced from #{oldsize}kB to #{newsize}kB"

--- a/plugins/purgecss_builder.rb
+++ b/plugins/purgecss_builder.rb
@@ -21,7 +21,7 @@ class PurgeCSS < SiteBuilder
 
           Bridgetown.logger.info 'PurgeCSS', "Purging #{css_file}"
           oldsize = File.stat(css_path).size / 1000
-          system "./node_modules/.bin/purgecss -c purgecss.config.js -css #{css_path} --output #{css_path}"
+          system "./node_modules/.bin/purgecss -c purgecss.config.js --css #{css_path} --output #{css_path}"
           newsize = File.stat(css_path).size / 1000
           if newsize < oldsize
             Bridgetown.logger.info 'PurgeCSS', "Done! File size reduced from #{oldsize}kB to #{newsize}kB"

--- a/plugins/purgecss_builder.rb
+++ b/plugins/purgecss_builder.rb
@@ -2,29 +2,30 @@ class PurgeCSS < SiteBuilder
   def build
     unless config[:watch] # don't run in "watch mode"
       hook :site, :post_write do
-        purgecss_file = site.in_root_dir("purgecss.config.js")
+        purgecss_file = site.in_root_dir('purgecss.config.js')
         unless File.exist?(purgecss_file)
           config_js = <<~PURGE
-              module.exports = {
-                content: ['frontend/javascript/*.js','./build/**/*.html'],
-                build: "./build/_bridgetown/static/css"
-              }
+            module.exports = {
+              content: ['frontend/javascript/*.js','./build/**/*.html'],
+              build: "./build/_bridgetown/static/css"
+            }
           PURGE
           File.write(purgecss_file, config_js.strip)
         end
-        manifest_file = site.in_root_dir(".bridgetown-webpack", "manifest.json")
+        manifest_file = site.in_root_dir('.bridgetown-webpack', 'manifest.json')
         if File.exist?(manifest_file)
           manifest = JSON.parse(File.read(manifest_file))
-          css_file = manifest["main.css"].split("/").last
-          css_path = ["build", "_bridgetown", "static", "css", css_file].join("/")
-          Bridgetown.logger.info "PurgeCSS", "Purging \#{css_file}"
+          css_file = manifest['main.css'].split('/').last
+          css_path = ['build', '_bridgetown', 'static', 'css', css_file].join('/')
+
+          Bridgetown.logger.info 'PurgeCSS', "Purging #{css_file}"
           oldsize = File.stat(css_path).size / 1000
-          system "./node_modules/.bin/purgecss -c purgecss.config.js -css \#{css_path}"
+          system "./node_modules/.bin/purgecss -c purgecss.config.js -css #{css_path}"
           newsize = File.stat(css_path).size / 1000
           if newsize < oldsize
-            Bridgetown.logger.info "PurgeCSS", "Done! File size reduced from \#{oldsize}kB to \#{newsize}kB"
+            Bridgetown.logger.info 'PurgeCSS', "Done! File size reduced from #{oldsize}kB to #{newsize}kB"
           else
-            Bridgetown.logger.info "PurgeCSS", "Done. No apparent change in file size (\#{newsize}kB)."
+            Bridgetown.logger.info 'PurgeCSS', "Done. No apparent change in file size (#{newsize}kB)."
           end
         end
       end

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ['frontend/javascript/*.js','./build/**/*.html'],
+  content: ["frontend/javascript/*.js", "./build/**/*.html"],
   build: "./build/_bridgetown/static/css",
   defaultExtractor: content => {
     // Capture as liberally as possible, including things like `h-(screen-1.5)`
@@ -10,4 +10,4 @@ module.exports = {
 
     return broadMatches.concat(innerMatches)
   }
-}
+};

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  content: ['frontend/javascript/*.js','./build/**/*.html'],
+  build: "./build/_bridgetown/static/css"
+}

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,4 +1,13 @@
 module.exports = {
   content: ['frontend/javascript/*.js','./build/**/*.html'],
-  build: "./build/_bridgetown/static/css"
+  build: "./build/_bridgetown/static/css",
+  defaultExtractor: content => {
+    // Capture as liberally as possible, including things like `h-(screen-1.5)`
+    const broadMatches = content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || []
+
+    // Capture classes within other delimiters like .block(class="w-1/2") in Pug
+    const innerMatches = content.match(/[^<>"'`\s.()]*[^<>"'`\s.():]/g) || []
+
+    return broadMatches.concat(innerMatches)
+  }
 }


### PR DESCRIPTION
So yeah:

```
12:15:08 PM:        Minify HTML: Complete, Processed 12 file(s)
12:15:08 PM:            PurgeCSS Purging #{css_file}
12:15:08 PM: error: option '-css, --css <files>' argument missing
12:15:08 PM:            PurgeCSS Done. No apparent change in file size (#{newsize}kB).
```

So go me for now making it shout a bunch when it broke.