### PR TITLE
The 'direct' method is so much cleaner

### DIFF
--- a/src/_posts/2020-09-18-how-to-manage-external-links-via-rails-routes.md
+++ b/src/_posts/2020-09-18-how-to-manage-external-links-via-rails-routes.md
@@ -4,21 +4,20 @@ title: How to manage external links via Rails Routes
 description: Linking to a 3rd party site & want to a nifty helper method? Here is a neat trick I found to solve this.
 ---
 
+_**Note: This was updated on 2nd of November with the superior `direct` approach.**_
+
 Linking to external sites in Rails is pretty easy, you can normally just drop the URL as a string into your code & you're good to go.
 
 However, in a recent project I had a bunch of external links that would be used multiple times within within the application, and were highly likely to change in the future. So managing them from a single location was quite important.
 
-I discovered this neat trick within Rails Routes which allows you to reference external links & have them output a full URL.
+I discovered the [`direct`](https://guides.rubyonrails.org/routing.html#direct-routes) method within Rails Routes which allows you to reference external links & have them output a full URL.
 
 ```ruby
 # config/routes.rb
 Rails.application.routes.draw do
-  # Define your route with the to, host & protocol set
-  get 'contact',
-    to: redirect('https://example.com/contact'),
-    protocol: 'https://',
-    host: 'example.com',
-    as: :example_contact
+  direct :example_contact do
+    "https://example.com/contact"
+  end
 end
 ```
 


### PR DESCRIPTION
I found https://lipanski.com/posts/activestorage-cdn-rails-direct-route & it mentioned the [`direct`](https://guides.rubyonrails.org/routing.html#direct-routes) method in routes. It was 10x better.