### PR TITLE
Switching language to en-gb over en_gb

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en_GB">
+<html lang="en-gb">
   <head>
     {% render "head" site: site %}
   </head>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/113355546-d96a3500-9338-11eb-9ee0-80768c6832cd.png)

I was getting an error on WAZE, so I switched it out for `en-gb`