### PR TITLE
Adding "RSpec." before describe

### DIFF
--- a/src/_posts/2019-11-05-how-to-test-factory-bot-factories-with-rspec.md
+++ b/src/_posts/2019-11-05-how-to-test-factory-bot-factories-with-rspec.md
@@ -18,7 +18,7 @@ To do this in RSpec, I setup a file in `spec/factories_spec.rb` with the followi
 require 'rails_helper'
 
 RSpec.describe FactoryBot do
-  it { FactoryBot.lint traits: true }
+  it { FactoryBot.lint(traits: true) }
 end
 ```
 

--- a/src/_posts/2019-11-05-how-to-test-factory-bot-factories-with-rspec.md
+++ b/src/_posts/2019-11-05-how-to-test-factory-bot-factories-with-rspec.md
@@ -9,7 +9,7 @@ I'm a big fan of using [FactoryBot](https://github.com/thoughtbot/factory_bot) w
 
 One drawback when working with factories (and fixtures!) is when a models validation or schema change, causing your factory to no longer be valid. It can sometimes be a little unobvious on exactly where the issue is.
 
-A technique I use to help stop this, is to test the validity of the factories along with their traits at the start of my test suite. 
+A technique I use to help stop this, is to test the validity of the factories along with their traits at the start of my test suite.
 
 To do this in RSpec, I setup a file in `spec/factories_spec.rb` with the following contents:
 
@@ -17,7 +17,7 @@ To do this in RSpec, I setup a file in `spec/factories_spec.rb` with the followi
 # spec/factories_spec.rb
 require 'rails_helper'
 
-describe FactoryBot do
+RSpec.describe FactoryBot do
   it { FactoryBot.lint traits: true }
 end
 ```


### PR DESCRIPTION
Big thanks to @dorianmariefr for messaging me to mention the new RSpec default is to prepend the `describe` method with `RSpec.` along with suggesting I add parenthesis (Which is 10x better!) :)